### PR TITLE
don't catch database exceptions and ignore them

### DIFF
--- a/djcelery/schedulers.py
+++ b/djcelery/schedulers.py
@@ -169,20 +169,16 @@ class DatabaseScheduler(Scheduler):
         return s
 
     def schedule_changed(self):
+        # If MySQL is running with transaction isolation level
+        # REPEATABLE-READ (default), then we won't see changes done by
+        # other transactions until the current transaction is
+        # committed (Issue #41).
         try:
-            # If MySQL is running with transaction isolation level
-            # REPEATABLE-READ (default), then we won't see changes done by
-            # other transactions until the current transaction is
-            # committed (Issue #41).
-            try:
-                transaction.commit()
-            except transaction.TransactionManagementError:
-                pass  # not in transaction management.
+            transaction.commit()
+        except transaction.TransactionManagementError:
+            pass  # not in transaction management.
 
-            last, ts = self._last_timestamp, self.Changes.last_change()
-        except DATABASE_ERRORS as exc:
-            error('Database gave error: %r', exc, exc_info=1)
-            return False
+        last, ts = self._last_timestamp, self.Changes.last_change()
         try:
             if ts and ts > (last if last else ts):
                 return True


### PR DESCRIPTION
celery/django-celery#359

When the connection to the database disappears, should either implement
reconnection logic or fail hard. This change makes the schedule poller
(and celerybeat) fail hard so that other orchestration can deal with
this, for example by relaunching celerybeat.
